### PR TITLE
feat: add session id field to flight plan

### DIFF
--- a/.cspell.project-words.txt
+++ b/.cspell.project-words.txt
@@ -97,3 +97,4 @@ timeslot
 Thomasg
 Lcov
 seccomp
+AETH

--- a/client-grpc/src/simple_service.rs
+++ b/client-grpc/src/simple_service.rs
@@ -79,9 +79,11 @@ where
     ///     let pilot_id = "a2093c5e-9bbe-4f0f-97ee-276b43fa3759".to_owned();
     ///     let origin_vertipad_id = "53acfe06-dd9b-42e8-8cb4-12a2fb2fa693".to_owned();
     ///     let target_vertipad_id = "db67da52-2280-4316-8b29-9cf1bff65931".to_owned();
+    ///     let session_id = "AETH-SESSION-X".to_owned();
     ///     let data = Data {
     ///         flight_status: FlightStatus::Draft as i32,
     ///         vehicle_id,
+    ///         session_id,
     ///         pilot_id,
     ///         path: Some(GeoLineString { points: vec![] }),
     ///         weather_conditions: Some("Cloudy, low wind".to_owned()),

--- a/includes/flight_plan/mock.rs
+++ b/includes/flight_plan/mock.rs
@@ -170,6 +170,7 @@ fn _get_data_obj(days_from_now_min: i64, days_from_now_max: i64) -> Data {
     }
 
     Data {
+        session_id: "AETH00001".to_string(),
         pilot_id: Uuid::new_v4().to_string(),
         vehicle_id: Uuid::new_v4().to_string(),
         path: Some(path),

--- a/proto/svc-storage-grpc-flight_plan-service.proto
+++ b/proto/svc-storage-grpc-flight_plan-service.proto
@@ -61,11 +61,13 @@ service RpcService {
     //     let pilot_id = "a2093c5e-9bbe-4f0f-97ee-276b43fa3759".to_owned();
     //     let origin_vertipad_id = "53acfe06-dd9b-42e8-8cb4-12a2fb2fa693".to_owned();
     //     let target_vertipad_id = "db67da52-2280-4316-8b29-9cf1bff65931".to_owned();
+    //     let session_id = "AETH-SESSION-X";
     //     println!("Starting insert flight plan");
     //     match client
     //     .insert(tonic::Request::new(Data {
     //         flight_status: FlightStatus::Draft as i32,
     //         vehicle_id,
+    //         session_id,
     //         pilot_id,
     //         path: Some(GeoLineString { points: vec![] }),
     //         weather_conditions: Some("Cloudy, low wind".to_owned()),

--- a/proto/svc-storage-grpc-flight_plan.proto
+++ b/proto/svc-storage-grpc-flight_plan.proto
@@ -111,6 +111,8 @@ message Data {
     FlightStatus flight_status = 19;
     // flightPriority
     FlightPriority flight_priority = 20;
+    // session ID
+    string session_id = 21;
 }
 
 // Struct containing a `list` of flight_plan [Vec\<Object\>]


### PR DESCRIPTION
Flights need a unique recognizable < 20 character ID for U-space purposes (like "KLM 1234"). We currently store flights ids as a UUID, added a field for session IDs.